### PR TITLE
Replace angle brackets in explanations

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
           <dl>
             <dt>tr -d [:punct:]</dt><dd>delete all punctuation</dd>
             <dt>< foobar-in.txt</dt><dd>from foobar-in.txt</dd>
-            <dt>< foobar-out.txt</dt><dd>and save as foobar-out.txt</dd>
+            <dt>> foobar-out.txt</dt><dd>and save as foobar-out.txt</dd>
           </dl>
         </div>
       </div>
@@ -364,7 +364,7 @@
           <dl>
             <dt>tr [:upper:] [:lower:]</dt><dd>transform upper case letters to lower case letters</dd>
             <dt>< foobar-in.txt</dt><dd>in foobar-in.txt</dd>
-            <dt>< foobar-out.txt</dt><dd>and save as foobar-out.txt</dd>
+            <dt>> foobar-out.txt</dt><dd>and save as foobar-out.txt</dd>
           </dl>
         </div>
       </div>


### PR DESCRIPTION
The command examples are correct in their usage of `<` and `>` for reading from and writing to files, but the explanations had `<` instead of `>` for outputs.
